### PR TITLE
Fix MPD status problem when playing web streams

### DIFF
--- a/modules/MPDModule/MPDModule.js
+++ b/modules/MPDModule/MPDModule.js
@@ -35,8 +35,8 @@ MPDModule.prototype.update = function(data) {
     if(this.timeoutHandle)
         clearTimeout(this.timeoutHandle);
 
-    if(data.artist && data.title) {
-        this.now_playing.text(data.artist + " – " + data.title);
+    if(data.title) {
+        this.now_playing.text((data.artist ? data.artist + " – " : "") + data.title);
         if(data.state == "pause" || data.state == "stop")
             this.toggle_button
                 .removeClass("glyphicon-pause")


### PR DESCRIPTION
When playing a web stream that does not set the artist attribute via mpd,
the mpd status is a flickering "Stopped" status.
With this PR, the title of the stream is still shown when no artist is set.
