### PR TITLE
Fixes flickering problem when playing audiostreams

### DIFF
--- a/modules/MPDModule/MPDModule.js
+++ b/modules/MPDModule/MPDModule.js
@@ -58,7 +58,7 @@ MPDModule.prototype.update = function(data) {
     }
     this.root.show();
     var nextupdate = data.time - data.elapsed;
-    if(nextupdate < 10)
+    if(nextupdate < 10 || Number.isNaN(nextupdate))
         nextupdate = 10;
     if(nextupdate > 120)
         nextupdate = 120;


### PR DESCRIPTION
Some streams set an invalid value as song duration ("47:0").
In this case the calculation of nextupdate fails and returns NaN.
Now this just triggers the minimal update timeout if the result is NaN.
