### PR TITLE
Fix BSAG module error caused by invalid XML

### DIFF
--- a/modules/BSAGModule/BSAGModule.class.php
+++ b/modules/BSAGModule/BSAGModule.class.php
@@ -60,6 +60,10 @@ class BSAGModule extends BaseModule {
             #'clientType' => 'ANDROID',
         );
         $result_str = $this->file_get_contents_post($bsag_url, http_build_query($bsag_post));
+        $result_str = preg_replace_callback('/"(.*)"/Um', function($attr) {
+          return strip_tags($attr[0]);
+        }, $result_str);
+        
         $result = new SimpleXMLElement($result_str);
 
         $connections = array();


### PR DESCRIPTION
At the moment, the BSAG seems to return invalid XML code with tags inside of attributes.

```
<HIMMessage header="Umleitung der Buslinie 28 an der Universit&#228;t" 
lead="Aufgrund des Neubaus einer Fu&#223;g&#228;ngerbr&#252;cke ist die Wiener Stra&#223;e voll gesperrt. Die Linie 28 f&#228;hrt bis vsl. 27.12.2014 in beiden Richtungen Umleitungen &#252;ber den Hochschulring. Folgende Haltestellen sind davon betroffen:<br /><br />  Klagenfurter Stra&#223;e in beiden Richtungen: verlegt in den Hochschulring, Ecke Klagenfurter Stra&#223;e<br />    Universit&#228;t/Zentralbereich in beiden Richtungen: entf&#228;llt f&#252;r die Linie 28<br />    Universit&#228;t/NW1 in beiden Richtungen: entf&#228;llt f&#252;r die Linie 28<br />    Wiener Stra&#223;e in beiden Richtungen: entf&#228;llt f&#252;r die Linie 28<br />    Celsiusstra&#223;e in beiden Richtungen: entf&#228;llt f&#252;r die Linie 28<br />  Wilhelm-Herbst-Stra&#223;e in Richtung Emder Stra&#223;e: verlegt in den Hochschulring, Ecke Wiener Stra&#223;e<br /><br />" 
display="5" 
/>
```

So now attributes are regex-checked and stripped of any tag that might be inside.
